### PR TITLE
Make map height responsive

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -55,7 +55,7 @@ a {
 
 .map-wrapper {
   position: relative;
-  height: 400px;
+  height: clamp(220px, 50vw, 420px);
   border-radius: 0.75rem;
   overflow: hidden;
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- adjust the embedded map container to use a responsive clamp-based height so it fits within its card without overlapping adjacent text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc94e5cca4832f8b8bb34e9e74e282