### PR TITLE
Adjust CSP to allow external styles and scripts

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,12 +3,12 @@
     {
       "source": "/(.*)",
       "headers": [
-        {"key":"Strict-Transport-Security","value":"max-age=31536000; includeSubDomains; preload"},
-        {"key":"Content-Security-Policy","value":"default-src 'self'; img-src 'self' data: https:; script-src 'self'; style-src 'self' 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'"},
-        {"key":"X-Content-Type-Options","value":"nosniff"},
-        {"key":"X-Frame-Options","value":"DENY"},
-        {"key":"Referrer-Policy","value":"strict-origin-when-cross-origin"},
-        {"key":"Permissions-Policy","value":"geolocation=(), microphone=(), camera=()"}
+        {"key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload"},
+        {"key": "Content-Security-Policy", "value": "default-src 'self'; img-src 'self' https: data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; connect-src 'self'; frame-src 'self' https://www.google.com https://maps.google.com; base-uri 'none'; frame-ancestors 'none'"},
+        {"key": "X-Content-Type-Options", "value": "nosniff"},
+        {"key": "X-Frame-Options", "value": "DENY"},
+        {"key": "Referrer-Policy", "value": "strict-origin-when-cross-origin"},
+        {"key": "Permissions-Policy", "value": "geolocation=(), microphone=(), camera=()"}
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- update the Vercel CSP header to match the site requirements
- allow Tailwind CDN, Google Fonts, map embeds, and API requests so the CSS and UI load correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd74f930bc832fb3df283d41a69581