### PR TITLE
Update header logos for theme modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,12 +39,25 @@
     <div class="glass">
       <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-14 sm:h-16 flex items-center justify-between">
         <a href="#home" aria-current="page" class="relative z-10 flex items-center gap-2 focus:outline-none focus:ring-2 rounded-md" aria-label="Lokan home">
-          <img src="assets/logo-icon.svg" alt="Lokan logo" class="header-logo-icon" />
+          <img
+            id="headerLogoIcon"
+            src="1to1transparentdark.png"
+            data-light-src="1to1transparentlight.png"
+            data-dark-src="1to1transparentdark.png"
+            alt="Lokan logo"
+            class="header-logo-icon"
+          />
           <span class="sr-only">Lokan</span>
         </a>
 
         <div class="header-logo-center pointer-events-none">
-          <img src="assets/logo-wordmark.svg" alt="Lokan" />
+          <img
+            id="headerLogoWordmark"
+            src="logotransparentdark.png"
+            data-light-src="logotransparentlight.png"
+            data-dark-src="logotransparentdark.png"
+            alt="Lokan"
+          />
         </div>
 
         <nav aria-label="Primary" class="hidden md:flex items-center gap-6 text-sm relative z-10">

--- a/main.js
+++ b/main.js
@@ -14,6 +14,20 @@ document.documentElement.classList.add('js');
     root.setAttribute('data-theme', mode);
     const sun = document.getElementById('iconSun');
     const moon = document.getElementById('iconMoon');
+    const iconLogo = document.getElementById('headerLogoIcon');
+    const wordmarkLogo = document.getElementById('headerLogoWordmark');
+
+    const swapLogo = (img) => {
+      if (!img) return;
+      const lightSrc = img.getAttribute('data-light-src');
+      const darkSrc = img.getAttribute('data-dark-src');
+      if (mode === 'light' && lightSrc) {
+        img.src = lightSrc;
+      } else if (mode === 'dark' && darkSrc) {
+        img.src = darkSrc;
+      }
+    };
+
     if (sun && moon) {
       if (mode === 'light') {
         sun.classList.remove('hidden');
@@ -23,6 +37,9 @@ document.documentElement.classList.add('js');
         sun.classList.add('hidden');
       }
     }
+
+    swapLogo(iconLogo);
+    swapLogo(wordmarkLogo);
   }
 
   applyTheme(startTheme);


### PR DESCRIPTION
## Summary
- replace the header icon and wordmark with the new transparent logo assets
- update the theme toggle script to swap the appropriate light or dark logo source

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd79eaa540832f970ce08d8119c561