### PR TITLE
Update header logos for theme modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,12 +39,25 @@
     <div class="glass">
       <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-14 sm:h-16 flex items-center justify-between">
         <a href="#home" aria-current="page" class="relative z-10 flex items-center gap-2 focus:outline-none focus:ring-2 rounded-md" aria-label="Lokan home">
-          <img src="assets/logo-icon.svg" alt="Lokan logo" class="header-logo-icon" />
+          <img
+            id="headerLogoIcon"
+            src="1to1transparentdark.png"
+            data-light-src="1to1transparentlight.png"
+            data-dark-src="1to1transparentdark.png"
+            alt="Lokan logo"
+            class="header-logo-icon"
+          />
           <span class="sr-only">Lokan</span>
         </a>
 
         <div class="header-logo-center pointer-events-none">
-          <img src="assets/logo-wordmark.svg" alt="Lokan" />
+          <img
+            id="headerLogoWordmark"
+            src="logotransparentdark.png"
+            data-light-src="logotransparentlight.png"
+            data-dark-src="logotransparentdark.png"
+            alt="Lokan"
+          />
         </div>
 
         <nav aria-label="Primary" class="hidden md:flex items-center gap-6 text-sm relative z-10">
@@ -92,7 +105,17 @@
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
       <div class="pt-16 sm:pt-24 pb-12 sm:pb-20">
         <div class="max-w-3xl mx-auto text-center">
-          <h1 class="text-4xl sm:text-5xl md:text-6xl font-semibold tracking-tight">Lokan</h1>
+          <h1 class="hero-logo">
+            <span class="sr-only">Lokan</span>
+            <img
+              id="heroLogoWordmark"
+              src="logotransparentdark.png"
+              data-light-src="logotransparentlight.png"
+              data-dark-src="logotransparentdark.png"
+              alt=""
+              aria-hidden="true"
+            />
+          </h1>
 
           <p class="mt-4 text-white/80 max-w-xl mx-auto">Lokan integrates AI into everyday devices with verifiable safeguards, private on-device processing, and predictable automation.</p>
           <div class="mt-8 flex flex-wrap gap-3 justify-center">

--- a/main.js
+++ b/main.js
@@ -14,6 +14,21 @@ document.documentElement.classList.add('js');
     root.setAttribute('data-theme', mode);
     const sun = document.getElementById('iconSun');
     const moon = document.getElementById('iconMoon');
+    const iconLogo = document.getElementById('headerLogoIcon');
+    const wordmarkLogo = document.getElementById('headerLogoWordmark');
+    const heroLogo = document.getElementById('heroLogoWordmark');
+
+    const swapLogo = (img) => {
+      if (!img) return;
+      const lightSrc = img.getAttribute('data-light-src');
+      const darkSrc = img.getAttribute('data-dark-src');
+      if (mode === 'light' && lightSrc) {
+        img.src = lightSrc;
+      } else if (mode === 'dark' && darkSrc) {
+        img.src = darkSrc;
+      }
+    };
+
     if (sun && moon) {
       if (mode === 'light') {
         sun.classList.remove('hidden');
@@ -23,6 +38,10 @@ document.documentElement.classList.add('js');
         sun.classList.add('hidden');
       }
     }
+
+    swapLogo(iconLogo);
+    swapLogo(wordmarkLogo);
+    swapLogo(heroLogo);
   }
 
   applyTheme(startTheme);

--- a/styles.css
+++ b/styles.css
@@ -26,7 +26,6 @@ body {
   display: block;
   object-fit: cover;
   border-radius: 1rem;
-  box-shadow: 0 8px 20px rgba(34, 211, 238, 0.25);
 }
 
 @media (min-width: 640px) {
@@ -47,6 +46,18 @@ body {
   width: clamp(160px, 28vw, 280px);
   height: auto;
   opacity: 0.92;
+  display: block;
+}
+
+.hero-logo {
+  margin: 0;
+  display: flex;
+  justify-content: center;
+}
+
+.hero-logo img {
+  width: clamp(200px, 60vw, 480px);
+  height: auto;
   display: block;
 }
 


### PR DESCRIPTION
## Summary
- replace the header icon and hero wordmark with the new transparent logo assets for each theme
- update the theme toggle script to keep the header and hero logos in sync with the active mode
- remove the colored glow from the header icon so the logo renders cleanly

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd79eaa540832f970ce08d8119c561