### PR TITLE
Remove sticky header logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,27 +52,9 @@
   <header class="sticky top-0 z-40">
     <div class="glass">
       <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 h-14 sm:h-16 flex items-center justify-between">
-        <a href="#home" aria-current="page" class="relative z-10 flex items-center gap-2 focus:outline-none focus:ring-2 rounded-md" aria-label="Lokan home">
-          <img
-            id="headerLogoIcon"
-            src="1to1transparentdark.png"
-            data-light-src="1to1transparentlight.png"
-            data-dark-src="1to1transparentdark.png"
-            alt="Lokan logo"
-            class="header-logo-icon"
-          />
-          <span class="sr-only">Lokan</span>
+        <a href="#home" aria-current="page" class="relative z-10 flex items-center gap-2 text-sm font-semibold tracking-tight focus:outline-none focus:ring-2 rounded-md" aria-label="Lokan home">
+          <span>Lokan</span>
         </a>
-
-        <div class="header-logo-center pointer-events-none">
-          <img
-            id="headerLogoWordmark"
-            src="logotransparentdark.png"
-            data-light-src="logotransparentlight.png"
-            data-dark-src="logotransparentdark.png"
-            alt="Lokan"
-          />
-        </div>
 
         <nav aria-label="Primary" class="hidden md:flex items-center gap-6 text-sm relative z-10">
           <a href="#solutions" class="text-white/80 hover:text-white">Solutions</a>

--- a/main.js
+++ b/main.js
@@ -33,8 +33,6 @@ document.documentElement.classList.add('js');
         if (img.src !== abs) img.src = abs;
       }
     };
-    swap('headerLogoIcon');
-    swap('headerLogoWordmark');
     swap('heroLogoWordmark');
   }
 

--- a/styles.css
+++ b/styles.css
@@ -20,35 +20,6 @@ body {
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
 }
 
-.header-logo-icon {
-  width: 2.25rem;
-  height: 2.25rem;
-  display: block;
-  object-fit: cover;
-  border-radius: 1rem;
-}
-
-@media (min-width: 640px) {
-  .header-logo-icon {
-    width: 2.5rem;
-    height: 2.5rem;
-  }
-}
-
-.header-logo-center {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-}
-
-.header-logo-center img {
-  width: clamp(160px, 28vw, 280px);
-  height: auto;
-  opacity: 0.92;
-  display: block;
-}
-
 .hero-logo {
   margin: 0;
   display: flex;


### PR DESCRIPTION
## Summary
- remove the icon and centered wordmark from the sticky header and replace the home link with text
- clean up unused header logo styles and theme swapping logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd7f1bab5c832fa6ef3a9b57dbce8f